### PR TITLE
Fix: Delete not validated fields

### DIFF
--- a/config/routes.json
+++ b/config/routes.json
@@ -7,12 +7,12 @@
         "export": "default",
         "module": "$import(./modules/send-sms)"
       },
-      "methods": ["GET", "POST"],
-      "authentication": "Public",
+      "methods": [
+        "GET",
+        "POST"
+      ],
       "corsPolicy": "AnythingGoes",
-      "version": "None",
-      "key": "7d352a71-7306-47f4-9e69-8c93e10e3733",
-      "inboundBodySchema": "send-sms.json"
+      "version": "None"
     }
   ],
   "versions": [


### PR DESCRIPTION
## Description
- Deleted more not validated keys that cause errors when trying to test and validate the schema API such as `authentication, `key`, and `inboundBodySchema`